### PR TITLE
Fix lab selector and dashboard pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,23 +1,37 @@
 import { Routes, Route, NavLink, Navigate } from 'react-router-dom'
 import Login from './pages/login'
 import GroupList from './components/GroupList'
+import LabSelector from './pages/lab-selector'
+import DashboardPage from './pages/dashboard'
 
 export default function App() {
     return (
         <>
             {/* Quick demo nav (remove later if embedding in Canvas) */}
-            <nav style={{
-                display:'flex', gap:12, padding:'10px 16px', borderBottom:'1px solid #e5e7eb',
-                position:'sticky', top:0, background:'#fff', zIndex:10
-            }}>
+            <nav
+                style={{
+                    display: 'flex',
+                    gap: 12,
+                    padding: '10px 16px',
+                    borderBottom: '1px solid #e5e7eb',
+                    position: 'sticky',
+                    top: 0,
+                    background: '#fff',
+                    zIndex: 10,
+                }}
+            >
                 <NavLink to="/login">Login</NavLink>
                 <NavLink to="/groups">Groups</NavLink>
+                <NavLink to="/labs">Labs</NavLink>
+                <NavLink to="/dashboard">Dashboard</NavLink>
             </nav>
 
             <Routes>
                 <Route path="/" element={<Navigate to="/login" replace />} />
                 <Route path="/login" element={<Login />} />
                 <Route path="/groups" element={<GroupList />} />
+                <Route path="/labs" element={<LabSelector />} />
+                <Route path="/dashboard" element={<DashboardPage />} />
                 {/* optional 404 */}
                 <Route path="*" element={<Navigate to="/login" replace />} />
             </Routes>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -370,8 +370,10 @@ a.active { color: #4f46e5; }
     border-radius: 18px;
     padding: 24px;
     box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
-    display: grid;
+    display: flex;
+    flex-direction: column;
     gap: 18px;
+    height: 100%;
 }
 
 .dash-panel-wide {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -67,3 +67,510 @@ a.active { color: #4f46e5; }
 .gc-actions { margin-top: auto; display:flex; gap:8px; }
 .gc-btn { height: 36px; padding: 0 12px; border-radius: 10px; border: 0; cursor: pointer; background: linear-gradient(90deg, #6366f1, #22d3ee); color: white; font-weight: 700; }
 .gc-btn.ghost { background: transparent; color:#0f172a; border:1px solid #cbd5e1; font-weight:600; }
+
+/* ===== Lab selector ===== */
+.lab-shell {
+    min-height: calc(100% - 49px);
+    padding: 32px 24px 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.lab-header {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.lab-eyebrow {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #64748b;
+}
+
+.lab-title {
+    margin: 4px 0 8px 0;
+    font-size: 28px;
+    line-height: 1.25;
+}
+
+.lab-subtitle {
+    margin: 0;
+    color: #475569;
+    max-width: 560px;
+}
+
+.lab-controls {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.lab-search-label {
+    position: absolute;
+    clip: rect(1px, 1px, 1px, 1px);
+    padding: 0;
+    border: 0;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+}
+
+.lab-search {
+    width: min(360px, 100%);
+    height: 44px;
+    padding: 0 14px;
+    border: 1px solid #cbd5e1;
+    border-radius: 12px;
+    background: #fff;
+    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
+}
+
+.lab-search:focus {
+    outline: none;
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.lab-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    color: #475569;
+}
+
+.lab-list {
+    display: grid;
+    gap: 20px;
+}
+
+.lab-empty {
+    margin: 0;
+    color: #64748b;
+}
+
+.lab-card {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    padding: 24px;
+    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.lab-card-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.lab-card-module {
+    margin: 0;
+    font-size: 13px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #64748b;
+}
+
+.lab-card-title {
+    margin: 6px 0 0 0;
+    font-size: 22px;
+    line-height: 1.3;
+}
+
+.lab-card-status {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 13px;
+    font-weight: 600;
+    border: 1px solid #cbd5e1;
+    background: #f8fafc;
+    color: #0f172a;
+}
+
+.lab-card-status-open {
+    border-color: #c7d2fe;
+    background: #eef2ff;
+    color: #3730a3;
+}
+
+.lab-card-status-opens-soon {
+    border-color: #fde68a;
+    background: #fef3c7;
+    color: #92400e;
+}
+
+.lab-card-status-archived {
+    border-color: #fecaca;
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.lab-card-summary {
+    margin: 0;
+    color: #475569;
+}
+
+.lab-card-meta {
+    display: flex;
+    gap: 18px;
+    margin: 0;
+}
+
+.lab-card-meta div {
+    display: grid;
+    gap: 4px;
+}
+
+.lab-card-meta dt {
+    font-size: 13px;
+    color: #64748b;
+}
+
+.lab-card-meta dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.lab-card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.lab-card-primary,
+.lab-card-secondary {
+    height: 38px;
+    padding: 0 16px;
+    border-radius: 10px;
+    font-weight: 600;
+    border: 0;
+    cursor: pointer;
+}
+
+.lab-card-primary {
+    background: linear-gradient(90deg, #6366f1, #22d3ee);
+    color: white;
+}
+
+.lab-card-secondary {
+    background: transparent;
+    border: 1px solid #cbd5e1;
+    color: #0f172a;
+}
+
+/* ===== Dashboard ===== */
+.dash-shell {
+    min-height: calc(100% - 49px);
+    padding: 32px 24px 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.dash-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+
+.dash-eyebrow {
+    margin: 0;
+    font-size: 14px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #64748b;
+}
+
+.dash-title {
+    margin: 6px 0 8px 0;
+    font-size: 32px;
+}
+
+.dash-subtitle {
+    margin: 0;
+    color: #475569;
+    max-width: 520px;
+}
+
+.dash-refresh {
+    height: 38px;
+    padding: 0 18px;
+    border-radius: 10px;
+    border: 1px solid #cbd5e1;
+    background: #f8fafc;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.dash-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.dash-card {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    padding: 20px;
+    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 6px;
+}
+
+.dash-card-label {
+    margin: 0;
+    font-size: 14px;
+    color: #64748b;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.dash-card-value {
+    margin: 0;
+    font-size: 28px;
+    font-weight: 700;
+}
+
+.dash-card-helper {
+    margin: 0;
+    font-size: 13px;
+    color: #475569;
+}
+
+.dash-main {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 16px;
+    align-items: start;
+}
+
+.dash-panel {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    padding: 24px;
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 18px;
+}
+
+.dash-panel-wide {
+    grid-column: span 1;
+}
+
+.dash-panel-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.dash-panel-title {
+    margin: 0;
+    font-size: 20px;
+}
+
+.dash-panel-subtitle {
+    margin: 6px 0 0 0;
+    color: #64748b;
+    font-size: 14px;
+}
+
+.dash-panel-button {
+    height: 34px;
+    padding: 0 14px;
+    border-radius: 8px;
+    border: 1px solid #cbd5e1;
+    background: #f1f5f9;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.dash-activity {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 14px;
+}
+
+.dash-activity-row {
+    display: grid;
+    grid-template-columns: 18px 1fr;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.dash-activity-indicator {
+    width: 12px;
+    height: 12px;
+    border-radius: 999px;
+    margin-top: 4px;
+    background: #38bdf8;
+}
+
+.dash-activity-pass .dash-activity-indicator {
+    background: #22c55e;
+}
+
+.dash-activity-return .dash-activity-indicator {
+    background: #f97316;
+}
+
+.dash-activity-label {
+    margin: 0;
+    font-weight: 600;
+}
+
+.dash-activity-time {
+    margin: 4px 0 0 0;
+    color: #64748b;
+    font-size: 13px;
+}
+
+.dash-actions {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 12px;
+}
+
+.dash-action {
+    width: 100%;
+    border: 1px solid #e2e8f0;
+    background: #f8fafc;
+    border-radius: 14px;
+    padding: 14px 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    text-align: left;
+    cursor: pointer;
+}
+
+.dash-action-icon {
+    font-size: 20px;
+}
+
+.dash-action-label {
+    display: block;
+    font-weight: 600;
+}
+
+.dash-action-helper {
+    display: block;
+    margin-top: 4px;
+    font-size: 13px;
+    color: #64748b;
+}
+
+.dash-schedule {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 16px;
+}
+
+.dash-schedule-row {
+    display: grid;
+    grid-template-columns: 80px 1fr auto;
+    gap: 18px;
+    align-items: center;
+    padding: 12px 0;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.dash-schedule-row:last-child {
+    border-bottom: none;
+}
+
+.dash-schedule-time {
+    display: grid;
+    justify-items: center;
+    gap: 2px;
+}
+
+.dash-schedule-hour {
+    font-size: 18px;
+    font-weight: 700;
+}
+
+.dash-schedule-meridiem {
+    font-size: 12px;
+    color: #64748b;
+}
+
+.dash-schedule-title {
+    margin: 0 0 4px 0;
+    font-weight: 600;
+}
+
+.dash-schedule-meta {
+    margin: 0;
+    color: #64748b;
+    font-size: 13px;
+}
+
+.dash-schedule-status {
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: #f1f5f9;
+    border: 1px solid #cbd5e1;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+@media (max-width: 900px) {
+    .dash-main {
+        grid-template-columns: 1fr;
+    }
+
+    .dash-panel-wide {
+        grid-column: auto;
+    }
+}
+
+@media (max-width: 640px) {
+    .lab-shell,
+    .dash-shell {
+        padding: 24px 16px 40px;
+    }
+
+    .dash-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .dash-schedule-row {
+        grid-template-columns: 1fr;
+        gap: 8px;
+    }
+
+    .dash-schedule-time {
+        justify-items: flex-start;
+        grid-auto-flow: column;
+        gap: 8px;
+    }
+
+    .dash-schedule-status {
+        justify-self: flex-start;
+    }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -357,7 +357,11 @@ a.active { color: #4f46e5; }
     display: grid;
     grid-template-columns: 2fr 1fr;
     gap: 16px;
-    align-items: start;
+    align-items: stretch;
+}
+
+.dash-main > * {
+    height: 100%;
 }
 
 .dash-panel {

--- a/frontend/src/pages/dashboard.jsx
+++ b/frontend/src/pages/dashboard.jsx
@@ -1,295 +1,132 @@
-"use client"
+const stats = [
+    { id: 'students', label: 'Total students', value: '127', helper: 'Enrolled this term' },
+    { id: 'pending', label: 'Pending check-offs', value: '23', helper: 'Awaiting review' },
+    { id: 'active', label: 'Active labs', value: '5', helper: '2 due this week' },
+    { id: 'pass-rate', label: 'Pass rate', value: '89%', helper: '+3% vs. last lab' },
+]
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
+const activity = [
+    { id: 1, label: 'Sarah Chen • Lab 1 Checkpoint 3 PASSED', time: '2 minutes ago', tone: 'pass' },
+    { id: 2, label: 'Mike Johnson • Lab 2 Checkpoint 1 RETURNED', time: '8 minutes ago', tone: 'return' },
+    { id: 3, label: 'Alex Kim submitted Lab 1 Checkpoint 4', time: '15 minutes ago', tone: 'info' },
+    { id: 4, label: 'Emma Davis completed Lab 1 (all checkpoints passed)', time: '32 minutes ago', tone: 'pass' },
+]
+
+const quickActions = [
+    { id: 'review', label: 'Review pending submissions', description: 'View groups waiting for a check-off', icon: '📝' },
+    { id: 'create', label: 'Create new lab assignment', description: 'Draft checkpoints and scoring rubric', icon: '🧪' },
+    { id: 'schedule', label: 'View lab schedule', description: 'See upcoming sessions by location', icon: '🗓️' },
+    { id: 'bulk', label: 'Bulk check-off tool', description: 'Apply an outcome to multiple groups', icon: '⚡' },
+]
+
+const schedule = [
+    { id: 'session-1', time: '10:00 AM', title: 'Lab 1 Check-offs', meta: 'Room CS-201 • 8 students pending', status: 'In progress' },
+    { id: 'session-2', time: '1:30 PM', title: 'Lab 2 Check-offs', meta: 'Room CS-205 • 15 students pending', status: 'Upcoming' },
+    { id: 'session-3', time: '3:00 PM', title: 'Office Hours — Lab Help', meta: 'Room CS-101 • Open session', status: 'Scheduled' },
+]
 
 export default function DashboardPage() {
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <Navigation />
-
-      <div className="container mx-auto px-6 py-8">
-        {/* Header */}
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">CS Lab Dashboard</h1>
-          <p className="text-gray-600 mt-2">Track student progress and manage lab check-offs</p>
-        </div>
-
-        {/* Stats Cards */}
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 mb-8">
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Total Students</CardTitle>
-              <div className="h-4 w-4 text-muted-foreground">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-                  <circle cx="9" cy="7" r="4" />
-                  <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-                  <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-                </svg>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">127</div>
-              <p className="text-xs text-muted-foreground">Enrolled students</p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Pending Check-offs</CardTitle>
-              <div className="h-4 w-4 text-muted-foreground">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <circle cx="12" cy="12" r="10" />
-                  <polyline points="12,6 12,12 16,14" />
-                </svg>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">23</div>
-              <p className="text-xs text-muted-foreground">Awaiting review</p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Active Labs</CardTitle>
-              <div className="h-4 w-4 text-muted-foreground">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-                  <polyline points="14,2 14,8 20,8" />
-                </svg>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">2</div>
-              <p className="text-xs text-muted-foreground">2 due this week</p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Pass Rate</CardTitle>
-              <div className="h-4 w-4 text-muted-foreground">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <polyline points="22,12 18,12 15,21 9,3 6,12 2,12" />
-                </svg>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">89%</div>
-              <p className="text-xs text-muted-foreground">+3% from last lab</p>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Main Content Grid */}
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {/* Recent Activity */}
-          <Card className="lg:col-span-2">
-            <CardHeader>
-              <CardTitle>Recent Check-off Activity</CardTitle>
-              <CardDescription>Latest student submissions and check-offs</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                <div className="flex items-center space-x-4">
-                  <div className="w-2 h-2 bg-green-600 rounded-full"></div>
-                  <div className="flex-1">
-                    <p className="text-sm font-medium">Sarah Chen - Lab 1 Checkpoint 3 PASSED</p>
-                    <p className="text-xs text-gray-500">2 minutes ago</p>
-                  </div>
+    return (
+        <main className="dash-shell">
+            <header className="dash-header">
+                <div>
+                    <p className="dash-eyebrow">Today&apos;s overview</p>
+                    <h1 className="dash-title">CS Lab Dashboard</h1>
+                    <p className="dash-subtitle">Track group progress and move quickly between check-off tasks.</p>
                 </div>
-                <div className="flex items-center space-x-4">
-                  <div className="w-2 h-2 bg-red-600 rounded-full"></div>
-                  <div className="flex-1">
-                    <p className="text-sm font-medium">Mike Johnson - Lab 2 Checkpoint 1 RETURNED</p>
-                    <p className="text-xs text-gray-500">8 minutes ago</p>
-                  </div>
-                </div>
-                <div className="flex items-center space-x-4">
-                  <div className="w-2 h-2 bg-blue-600 rounded-full"></div>
-                  <div className="flex-1">
-                    <p className="text-sm font-medium">New submission: Alex Kim - Lab 1 Checkpoint 4</p>
-                    <p className="text-xs text-gray-500">15 minutes ago</p>
-                  </div>
-                </div>
-                <div className="flex items-center space-x-4">
-                  <div className="w-2 h-2 bg-green-600 rounded-full"></div>
-                  <div className="flex-1">
-                    <p className="text-sm font-medium">Emma Davis - Lab 1 Complete (All checkpoints passed)</p>
-                    <p className="text-xs text-gray-500">32 minutes ago</p>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+                <button type="button" className="dash-refresh" onClick={() => alert('Refresh data')}>
+                    Refresh data
+                </button>
+            </header>
 
-          {/* Quick Actions */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Quick Actions</CardTitle>
-              <CardDescription>Common check-off tasks</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
-                <Button className="w-full justify-start bg-transparent" variant="outline">
-                  <svg
-                    className="mr-2 h-4 w-4"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <polyline points="9,11 12,14 22,4" />
-                    <path d="M21,12v7a2,2 0 0,1 -2,2H5a2,2 0 0,1 -2,-2V5a2,2 0 0,1 2,-2h11" />
-                  </svg>
-                  Review Pending Submissions
-                </Button>
-                <Button className="w-full justify-start bg-transparent" variant="outline">
-                  <svg
-                    className="mr-2 h-4 w-4"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-                    <polyline points="14,2 14,8 20,8" />
-                  </svg>
-                  Create New Lab Assignment
-                </Button>
-                <Button className="w-full justify-start bg-transparent" variant="outline">
-                  <svg
-                    className="mr-2 h-4 w-4"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
-                    <line x1="16" x2="16" y1="2" y2="6" />
-                    <line x1="8" x2="8" y1="2" y2="6" />
-                    <line x1="3" x2="21" y1="10" y2="10" />
-                  </svg>
-                  View Lab Schedule
-                </Button>
-                <Button className="w-full justify-start bg-transparent" variant="outline">
-                  <svg
-                    className="mr-2 h-4 w-4"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M9 12l2 2 4-4" />
-                    <path d="M21 12c.552 0 1-.448 1-1V5c0-.552-.448-1-1-1H3c-.552 0-1 .448-1 1v6c0 .552.448 1 1 1h9" />
-                  </svg>
-                  Bulk Check-off Tool
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
+            <section className="dash-stats" aria-label="Summary statistics">
+                {stats.map((item) => (
+                    <article key={item.id} className="dash-card dash-card-stat">
+                        <p className="dash-card-label">{item.label}</p>
+                        <p className="dash-card-value">{item.value}</p>
+                        <p className="dash-card-helper">{item.helper}</p>
+                    </article>
+                ))}
+            </section>
 
-        {/* Upcoming Schedule */}
-        <Card className="mt-6">
-          <CardHeader>
-            <CardTitle>Today's Lab Sessions</CardTitle>
-            <CardDescription>Scheduled check-off sessions and office hours</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              <div className="flex items-center justify-between p-4 border rounded-lg">
-                <div className="flex items-center space-x-4">
-                  <div className="text-center">
-                    <div className="text-sm font-medium">10:00</div>
-                    <div className="text-xs text-gray-500">AM</div>
-                  </div>
-                  <div>
-                    <p className="font-medium">Lab 1 Check-offs</p>
-                    <p className="text-sm text-gray-500">Room CS-201 • 8 students pending</p>
-                  </div>
-                </div>
-                <Badge variant="outline">In Progress</Badge>
-              </div>
+            <section className="dash-main">
+                <article className="dash-panel dash-panel-wide" aria-labelledby="dash-activity">
+                    <header className="dash-panel-header">
+                        <div>
+                            <h2 id="dash-activity" className="dash-panel-title">
+                                Recent check-off activity
+                            </h2>
+                            <p className="dash-panel-subtitle">Latest submissions from students and groups.</p>
+                        </div>
+                        <button type="button" className="dash-panel-button" onClick={() => alert('Open activity log')}>
+                            View all
+                        </button>
+                    </header>
+                    <ul className="dash-activity">
+                        {activity.map((item) => (
+                            <li key={item.id} className={`dash-activity-row dash-activity-${item.tone}`}>
+                                <span aria-hidden="true" className="dash-activity-indicator" />
+                                <div>
+                                    <p className="dash-activity-label">{item.label}</p>
+                                    <p className="dash-activity-time">{item.time}</p>
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                </article>
 
-              <div className="flex items-center justify-between p-4 border rounded-lg">
-                <div className="flex items-center space-x-4">
-                  <div className="text-center">
-                    <div className="text-sm font-medium">01:30</div>
-                    <div className="text-xs text-gray-500">PM</div>
-                  </div>
-                  <div>
-                    <p className="font-medium">Lab 2 Check-offs</p>
-                    <p className="text-sm text-gray-500">Room CS-205 • 15 students pending</p>
-                  </div>
-                </div>
-                <Badge>Upcoming</Badge>
-              </div>
+                <article className="dash-panel" aria-labelledby="dash-actions">
+                    <header className="dash-panel-header">
+                        <div>
+                            <h2 id="dash-actions" className="dash-panel-title">
+                                Quick actions
+                            </h2>
+                            <p className="dash-panel-subtitle">Jump straight into the most common workflows.</p>
+                        </div>
+                    </header>
+                    <ul className="dash-actions">
+                        {quickActions.map((item) => (
+                            <li key={item.id}>
+                                <button type="button" className="dash-action" onClick={() => alert(item.label)}>
+                                    <span className="dash-action-icon" aria-hidden="true">
+                                        {item.icon}
+                                    </span>
+                                    <span>
+                                        <span className="dash-action-label">{item.label}</span>
+                                        <span className="dash-action-helper">{item.description}</span>
+                                    </span>
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                </article>
+            </section>
 
-              <div className="flex items-center justify-between p-4 border rounded-lg">
-                <div className="flex items-center space-x-4">
-                  <div className="text-center">
-                    <div className="text-sm font-medium">03:00</div>
-                    <div className="text-xs text-gray-500">PM</div>
-                  </div>
-                  <div>
-                    <p className="font-medium">Office Hours - Lab Help</p>
-                    <p className="text-sm text-gray-500">Room CS-101 • Open session</p>
-                  </div>
-                </div>
-                <Badge variant="secondary">Scheduled</Badge>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
-  )
+            <section className="dash-panel" aria-labelledby="dash-schedule">
+                <header className="dash-panel-header">
+                    <div>
+                        <h2 id="dash-schedule" className="dash-panel-title">
+                            Today&apos;s lab sessions
+                        </h2>
+                        <p className="dash-panel-subtitle">Scheduled check-offs and office hours.</p>
+                    </div>
+                </header>
+                <ul className="dash-schedule">
+                    {schedule.map((item) => (
+                        <li key={item.id} className="dash-schedule-row">
+                            <div className="dash-schedule-time">
+                                <span className="dash-schedule-hour">{item.time.split(' ')[0]}</span>
+                                <span className="dash-schedule-meridiem">{item.time.split(' ')[1]}</span>
+                            </div>
+                            <div className="dash-schedule-details">
+                                <p className="dash-schedule-title">{item.title}</p>
+                                <p className="dash-schedule-meta">{item.meta}</p>
+                            </div>
+                            <span className="dash-schedule-status">{item.status}</span>
+                        </li>
+                    ))}
+                </ul>
+            </section>
+        </main>
+    )
 }

--- a/frontend/src/pages/lab-selector.jsx
+++ b/frontend/src/pages/lab-selector.jsx
@@ -1,0 +1,120 @@
+import { useMemo, useState } from 'react'
+
+const labs = [
+    {
+        id: 'lab-01',
+        name: 'Lab 1 • Command Line Scavenger Hunt',
+        module: 'Module 1: Orientation',
+        due: 'Jan 24',
+        status: 'Open',
+        summary: 'Students practice navigating the terminal and turning in a transcript of commands.',
+        checkpoints: 3,
+    },
+    {
+        id: 'lab-02',
+        name: 'Lab 2 • Git Collaboration',
+        module: 'Module 2: Version Control',
+        due: 'Jan 31',
+        status: 'Opens soon',
+        summary: 'Teams resolve merge conflicts and submit a pull request for review.',
+        checkpoints: 4,
+    },
+    {
+        id: 'lab-03',
+        name: 'Lab 3 • Data Structures',
+        module: 'Module 3: Arrays & Maps',
+        due: 'Feb 7',
+        status: 'Archived',
+        summary: 'Autograded warmup followed by instructor check-off of coding style.',
+        checkpoints: 5,
+    },
+]
+
+export default function LabSelector() {
+    const [query, setQuery] = useState('')
+    const [showArchived, setShowArchived] = useState(false)
+
+    const filteredLabs = useMemo(() => {
+        return labs.filter((lab) => {
+            if (!showArchived && lab.status === 'Archived') return false
+            if (!query.trim()) return true
+            const normalized = query.trim().toLowerCase()
+            return lab.name.toLowerCase().includes(normalized) || lab.module.toLowerCase().includes(normalized)
+        })
+    }, [query, showArchived])
+
+    return (
+        <main className="lab-shell">
+            <header className="lab-header">
+                <div>
+                    <p className="lab-eyebrow">Current Course</p>
+                    <h1 className="lab-title">CS 101 – Introduction to Programming Labs</h1>
+                    <p className="lab-subtitle">Select a lab to view active groups, checkpoints, and recent activity.</p>
+                </div>
+                <div className="lab-controls" role="search">
+                    <label className="lab-search-label" htmlFor="lab-query">
+                        Search labs
+                    </label>
+                    <input
+                        id="lab-query"
+                        type="search"
+                        className="lab-search"
+                        placeholder="Filter by name or module"
+                        value={query}
+                        onChange={(event) => setQuery(event.target.value)}
+                    />
+                    <label className="lab-toggle">
+                        <input
+                            type="checkbox"
+                            checked={showArchived}
+                            onChange={(event) => setShowArchived(event.target.checked)}
+                        />
+                        Include archived labs
+                    </label>
+                </div>
+            </header>
+
+            <section aria-live="polite" className="lab-list">
+                {filteredLabs.length === 0 ? (
+                    <p className="lab-empty">No labs match the current filters.</p>
+                ) : (
+                    filteredLabs.map((lab) => (
+                        <article key={lab.id} className="lab-card">
+                            <header className="lab-card-header">
+                                <div>
+                                    <p className="lab-card-module">{lab.module}</p>
+                                    <h2 className="lab-card-title">{lab.name}</h2>
+                                </div>
+                                <span className={`lab-card-status lab-card-status-${lab.status.toLowerCase().replace(/\s+/g, '-')}`}>
+                                    {lab.status}
+                                </span>
+                            </header>
+
+                            <p className="lab-card-summary">{lab.summary}</p>
+
+                            <dl className="lab-card-meta">
+                                <div>
+                                    <dt>Checkpoints</dt>
+                                    <dd>{lab.checkpoints}</dd>
+                                </div>
+                                <div>
+                                    <dt>Next due</dt>
+                                    <dd>{lab.due}</dd>
+                                </div>
+                            </dl>
+
+                            <footer className="lab-card-actions">
+                                <button type="button" className="lab-card-primary" onClick={() => alert(`Open ${lab.name}`)}>
+                                    Open lab dashboard
+                                </button>
+                                <button type="button" className="lab-card-secondary" onClick={() => alert(`View rubric for ${lab.name}`)}>
+                                    View rubric
+                                </button>
+                            </footer>
+                        </article>
+                    ))
+                )}
+            </section>
+        </main>
+    )
+}


### PR DESCRIPTION
## Summary
- implement the lab selector page with filtering, lab cards, and call-to-action buttons
- rebuild the dashboard page using local data, accessible layout, and quick actions
- add styling and routes so the new pages render correctly in the demo navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d332a66b4c832da4b8ebf3f99fd156